### PR TITLE
Remove deprecated `has_rdoc` usage from `thrift.gemspec`

### DIFF
--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
   s.extensions  = ['ext/extconf.rb']
 
-  s.has_rdoc      = true
   s.rdoc_options  = %w[--line-numbers --inline-source --title Thrift --main README]
 
   s.rubyforge_project = 'thrift'


### PR DESCRIPTION
<!-- Explain the changes in the pull request below: -->

Simply removes `has_rdoc` as it is deprecated with no replacement. See the following console warning. I'd imagine as `has_rdoc` is to be removed in Rubygems 4, this gem may run into issues come Rubygems 4's release.

```console
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed in Rubygems 4
Gem::Specification#has_rdoc= called from /Users/larouxn/.gem/ruby/ruby-3.3.0/bundler/gems/thrift-b109bdd1a4aa/lib/rb/thrift.gemspec:15.
```  

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  (not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [ ] Did you squash your changes to a single commit?  (not required, but preferred)
- [ ] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
